### PR TITLE
Upgrade to latest npm-registry-client to resolve #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/juliangruber/silent-npm-registry-client",
   "main": "index.js",
   "dependencies": {
-    "npm-registry-client": "~0.2.26",
+    "npm-registry-client": "~6.3.2",
     "xtend": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
This install pulled `semver@4.3.3` for me which will resolve the [nsp](https://nodesecurity.io) reported [semver vulnerability](https://nodesecurity.io/advisories/semver_redos)