### PR TITLE
use latest npm-registry-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/juliangruber/silent-npm-registry-client",
   "main": "index.js",
   "dependencies": {
-    "npm-registry-client": "~6.3.2",
+    "npm-registry-client": "~7.0.9",
     "xtend": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
Long story, but `npm-registry-client` v6.x has a [poorly declared dependency on `npmlog`](https://github.com/npm/npm-registry-client/blob/v6.3.3/package.json#L34) which causes problems with shrinkwrap.

This change updates to the latest version of the client where this optional dep is fixed. Since this is a major version change, it should be released as a major here as well.

Thanks!